### PR TITLE
Add .nojekyll to build for GitHub Pages

### DIFF
--- a/coast-game/package.json
+++ b/coast-game/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "next build --turbopack",
+    "build": "next build --turbopack && touch out/.nojekyll",
     "start": "next start",
     "lint": "eslint",
     "deploy:local": "next build"


### PR DESCRIPTION
## Summary
- ensure build step creates an `.nojekyll` file so GitHub Pages serves the export correctly

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Geist`/`Geist Mono` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d6af534883318d9fde4e1a67e918