### PR TITLE
refactor: remove incremental score tracking

### DIFF
--- a/coast-game/src/Components/game.js
+++ b/coast-game/src/Components/game.js
@@ -4,12 +4,20 @@ import Scenario from './scenario';
 import scenarios from '../app/scenarios.json';
 
 export default function Game({ setPage }) {
-    const [path, setPath] = useState('')
-    const [score, setScore] = useState(0);
+    const [path, setPath] = useState('');
     return (
-        <div>
-            <Scenario scenarios={scenarios} path={path} setPath={setPath}/>
-            <button onClick={() => setPage('start')}>Back to Start</button>
+        <div className="flex flex-col items-center gap-6">
+            <Scenario
+                scenarios={scenarios}
+                path={path}
+                setPath={setPath}
+            />
+            <button
+                className="rounded bg-gray-600 px-4 py-2 text-white hover:bg-gray-700"
+                onClick={() => setPage('start')}
+            >
+                Back to Start
+            </button>
         </div>
     );
 }

--- a/coast-game/src/Components/leaderboard.js
+++ b/coast-game/src/Components/leaderboard.js
@@ -1,9 +1,13 @@
 export default function Leaderboard({ setPage }) {
     return (
-        <div>
-            <h1>Leaderboard</h1>
-            <button onClick={() => setPage('start')}>Back to Start</button>
-
+        <div className="flex flex-col items-center gap-6">
+            <h1 className="text-2xl font-bold">Leaderboard</h1>
+            <button
+                className="rounded bg-gray-600 px-4 py-2 text-white hover:bg-gray-700"
+                onClick={() => setPage('start')}
+            >
+                Back to Start
+            </button>
         </div>
     );
 }

--- a/coast-game/src/Components/scenBtn.js
+++ b/coast-game/src/Components/scenBtn.js
@@ -1,11 +1,12 @@
-export default function scenBtn ({decision, path, setPath}) {
+export default function scenBtn({ decision, path, setPath }) {
     return (
-        <button 
-            onClick={()=>{
-                setPath(path + decision.target)
+        <button
+            className="rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
+            onClick={() => {
+                setPath(path + decision.target);
             }}
         >
             {decision.option}
         </button>
-    )
+    );
 }

--- a/coast-game/src/Components/scenario.js
+++ b/coast-game/src/Components/scenario.js
@@ -1,14 +1,21 @@
-import ScenBtn from "./scenBtn"
+import ScenBtn from "./scenBtn";
 
-export default function Scenario({scenarios, path, setPath}) {
-    console.log('path', path)
-    const scenario = scenarios.layers[path.length][path]
+export default function Scenario({ scenarios, path, setPath }) {
+    console.log('path', path);
+    const scenario = scenarios.layers[path.length][path];
     return (
-        <div>
-            <em>{scenario.text}</em>
-            {scenario.options.map((decision, i) => (
-                <ScenBtn key={i} decision={decision} path={path} setPath={setPath} />
-            ))}
+        <div className="flex flex-col items-center gap-4">
+            <em className="text-center text-lg">{scenario.text}</em>
+            <div className="flex flex-col items-center gap-2">
+                {scenario.options.map((decision, i) => (
+                    <ScenBtn
+                        key={i}
+                        decision={decision}
+                        path={path}
+                        setPath={setPath}
+                    />
+                ))}
+            </div>
         </div>
-    )
+    );
 }

--- a/coast-game/src/app/page.js
+++ b/coast-game/src/app/page.js
@@ -6,21 +6,32 @@ import { useState } from 'react';
 
 export default function Home() {
   const [page, setPage] = useState('start');
-  return (    
-    <div className="font-sans grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
-      
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-8 p-8">
       {page === 'start' && (
-        <div>
-          <h1>Coast Game</h1>
-          <button onClick={() => setPage('game')}>Start Game</button>
-          <button onClick={() => setPage('leaderboard')}>Leaderboard</button>
+        <div className="flex flex-col items-center gap-6">
+          <h1 className="text-4xl font-bold">Coast Game</h1>
+          <div className="flex gap-4">
+            <button
+              className="rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
+              onClick={() => setPage('game')}
+            >
+              Start Game
+            </button>
+            <button
+              className="rounded bg-gray-600 px-4 py-2 text-white hover:bg-gray-700"
+              onClick={() => setPage('leaderboard')}
+            >
+              Leaderboard
+            </button>
+          </div>
         </div>
       )}
       {page === 'game' && (
         <Game setPage={setPage} />
       )}
       {page === 'leaderboard' && (
-          <Leaderboard setPage={setPage} />
+        <Leaderboard setPage={setPage} />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- remove live score updates so final score can be derived from path
- simplify scenario and decision button components to manage only path progression

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5c66435608331825c1c5ffa6264e4