### PR TITLE
Add sequential fade-in animation for scenarios

### DIFF
--- a/coast-game/src/Components/scenario.js
+++ b/coast-game/src/Components/scenario.js
@@ -1,10 +1,34 @@
-import ScenBtn from "./scenBtn"
+import { useEffect, useState } from "react";
+import ScenBtn from "./scenBtn";
 
 export default function Scenario({scenario, path, setPath, setPage}) {
+    const [showOptions, setShowOptions] = useState(false);
+    const letters = scenario.text.split("");
+
+    useEffect(() => {
+        setShowOptions(false);
+        const duration = scenario.text.length * 50 + 500;
+        const timeout = setTimeout(() => setShowOptions(true), duration);
+        return () => clearTimeout(timeout);
+    }, [scenario.text]);
+
     return (
         <div className="stack-sm">
-            <em className="text-center text-lg">{scenario.text}</em>
-            <div className="stack-xs">
+            <em className="text-center text-lg block">
+                {letters.map((char, i) => (
+                    <span
+                        key={i}
+                        className="opacity-0"
+                        style={{
+                            animation: "fade-in 0.3s forwards",
+                            animationDelay: `${i * 50}ms`,
+                        }}
+                    >
+                        {char}
+                    </span>
+                ))}
+            </em>
+            <div className={`stack-xs transition-opacity duration-500 ${showOptions ? "opacity-100" : "opacity-0"}`}>
                 {scenario.options?.map((option, i) => (
                     <ScenBtn key={i} option={option} path={path} setPath={setPath} />
                 ))}

--- a/coast-game/src/app/globals.css
+++ b/coast-game/src/app/globals.css
@@ -71,6 +71,15 @@ body {
     }
   }
 
+  @keyframes fade-in {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+
   .wave-bg {
     background-image: url("/wave.svg");
     background-repeat: repeat-x;


### PR DESCRIPTION
## Summary
- Animate scenario text by fading in characters sequentially from left to right
- Reveal option buttons with a fade-in after text animation completes
- Define global `fade-in` keyframes for animation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a8709094f483318343990574aef70b