### PR TITLE
Fix background image path for production build

### DIFF
--- a/coast-game/next.config.mjs
+++ b/coast-game/next.config.mjs
@@ -9,6 +9,9 @@ const config = {
   images: { unoptimized: true },        // GH Pages: no image optimizer
   basePath,                             // serve under /coastal-game
   assetPrefix: basePath + '/',          // asset URLs under /coastal-game
+  env: {                                // expose basePath to client code
+    NEXT_PUBLIC_BASE_PATH: basePath,
+  },
 }
 
 export default config

--- a/coast-game/src/app/globals.css
+++ b/coast-game/src/app/globals.css
@@ -26,7 +26,6 @@
 }
 
 body {
-  background: url('/town.gif');
   background-size: cover;
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;

--- a/coast-game/src/app/layout.js
+++ b/coast-game/src/app/layout.js
@@ -17,9 +17,11 @@ export const metadata = {
 };
 
 export default function RootLayout({ children }) {
+  const basePath = process.env.NEXT_PUBLIC_BASE_PATH || "";
   return (
     <html lang="en">
       <body
+        style={{ backgroundImage: `url(${basePath}/town.gif)` }}
         className={`${geistSans.variable} ${geistMono.variable} antialiased wave-bg`}
       >
         {children}


### PR DESCRIPTION
## Summary
- expose Next.js `basePath` as `NEXT_PUBLIC_BASE_PATH`
- load `town.gif` background using the public base path
- remove hard-coded background image from CSS

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Geist` font files)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e5f433948331bedf2b390775d0ef