### PR TITLE
fix: enforce light theme and restore background video

### DIFF
--- a/coast-game/src/Components/scenario.js
+++ b/coast-game/src/Components/scenario.js
@@ -25,7 +25,7 @@ text-xs">
                 height={1000}
             />
             <div className="mx-auto w-3/5 max-sm:w-full bg-white p-8">
-                <p key={animKey} style={{"border-bottom": "solid"}} className="text-black text-center p-4 pb-2">
+                <p key={animKey} style={{"borderBottom": "solid"}} className="text-black text-center p-4 pb-2">
                     {letters.map((char, i) => (
                         <span
                             key={i}

--- a/coast-game/src/app/globals.css
+++ b/coast-game/src/app/globals.css
@@ -18,17 +18,12 @@
   --font-mono: var(--font-press-start), monospace;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #001d3d;
-    --foreground: #e0f7fa;
-  }
-}
-
 body {
+  background-color: var(--background);
   background-size: cover;
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
+  color-scheme: light;
 }
 
 .pixel-ui {
@@ -66,15 +61,6 @@ body {
 }
 
 @layer utilities {
-  @keyframes wave {
-    from {
-      background-position-x: 0;
-    }
-    to {
-      background-position-x: -1000px;
-    }
-  }
-
   @keyframes fade-in {
     from {
       opacity: 0;
@@ -83,11 +69,4 @@ body {
       opacity: 1;
     }
   }
-
-  /* .wave-bg {
-    background-image: url("/wave.svg");
-    background-repeat: repeat-x;
-    background-size: 1000px 100%;
-    animation: wave 15s linear infinite;
-  } */
 }

--- a/coast-game/src/app/globals.css
+++ b/coast-game/src/app/globals.css
@@ -1,13 +1,5 @@
 @import "tailwindcss";
 
-:root {
-  --background: #e0f7fa;
-  --foreground: #023e8a;
-  --ocean-light: #90e0ef;
-  --ocean: #00b4d8;
-  --ocean-dark: #0077b6;
-}
-
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
@@ -19,11 +11,9 @@
 }
 
 body {
-  background-color: var(--background);
   background-size: cover;
-  color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
-  color-scheme: light;
+  /* color-scheme: light; */
 }
 
 .pixel-ui {

--- a/coast-game/src/app/layout.js
+++ b/coast-game/src/app/layout.js
@@ -16,10 +16,16 @@ export default function RootLayout({ children }) {
   const basePath = process.env.NEXT_PUBLIC_BASE_PATH || "";
   return (
     <html lang="en" className={pressStart2P.variable}>
-      <body
-        style={{ backgroundImage: `url(${basePath}/town.mp4)` }}
-        className="antialiased wave-bg"
-      >
+      <body className="antialiased">
+        <video
+          className="fixed inset-0 -z-10 h-full w-full object-cover"
+          autoPlay
+          muted
+          loop
+          playsInline
+        >
+          <source src={`${basePath}/town.mp4`} type="video/mp4" />
+        </video>
         {children}
       </body>
     </html>


### PR DESCRIPTION
## Summary
- reintroduce `town.mp4` as background via `<video>` element for Chrome compatibility
- clean up unused wave animation utilities

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aae67866208331971e84580b55b8aa